### PR TITLE
Fix Pomodoro run script and dependencies

### DIFF
--- a/pomodoro/__main__.py
+++ b/pomodoro/__main__.py
@@ -1,0 +1,6 @@
+"""Allow running the package with python -m pomodoro."""
+
+from pomodoro.main import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The start.sh script uses 'python -m pomodoro' to launch the app, but the package was missing the __main__.py entry point file.